### PR TITLE
Reset workflow repository URL to master branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,3 +148,8 @@
 
 * Add option to resolve references to external files when reading Yaml files.
 * Support inclusion and import of files in instructions markdown text.
+
+
+### 0.9.2 - 2021-09-30
+
+* Reset hard-coded workflow repository URL to point to the master branch.

--- a/flowserv/model/workflow/repository.py
+++ b/flowserv/model/workflow/repository.py
@@ -14,8 +14,7 @@ from typing import Dict, List, Tuple
 
 
 """Repository URL."""
-# URL = 'https://raw.githubusercontent.com/scailfin/flowserv-workflow-repository/master/templates.json'
-URL = 'https://raw.githubusercontent.com/scailfin/flowserv-workflow-repository/flowserv/0.9.0/templates.json'
+URL = 'https://raw.githubusercontent.com/scailfin/flowserv-workflow-repository/master/templates.json'
 
 
 class WorkflowRepository(object):

--- a/flowserv/version.py
+++ b/flowserv/version.py
@@ -7,4 +7,4 @@
 # terms of the MIT License; see LICENSE file for more details.
 
 """Information about the current version of the flowServ package."""
-__version__ = '0.9.1'
+__version__ = '0.9.2'


### PR DESCRIPTION
This PR fixes a bug with the hard-coded URL for the workflow repository.