### PR TITLE
Bug/S3Volume.walk return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,3 +153,8 @@
 ### 0.9.2 - 2021-09-30
 
 * Reset hard-coded workflow repository URL to point to the master branch.
+
+
+### 0.9.3 - 2022-05-24
+
+* Fix issue with `S3Volume.walk` return value (\#95)

--- a/flowserv/version.py
+++ b/flowserv/version.py
@@ -7,4 +7,4 @@
 # terms of the MIT License; see LICENSE file for more details.
 
 """Information about the current version of the flowServ package."""
-__version__ = '0.9.2'
+__version__ = '0.9.3'

--- a/flowserv/volume/s3.py
+++ b/flowserv/volume/s3.py
@@ -273,7 +273,8 @@ class S3Volume(StorageVolume):
             prefix = ''
         else:
             prefix = src
-        return self.query(filter=util.join(self.prefix, prefix))
+        files = self.query(filter=util.join(self.prefix, prefix))
+        return [(key, S3File(bucket=self.bucket, key=key)) for key in files]
 
 
 # -- Helper functions --------------------------------------------------------

--- a/tests/volume/test_s3_storage.py
+++ b/tests/volume/test_s3_storage.py
@@ -48,10 +48,15 @@ def test_s3_mkdir(store):
 
 
 def test_s3_query_files(store, bucket_keys):
-    """Test querying a S3 bucket store."""
-    assert store.walk(src=None) == bucket_keys
-    assert store.walk(src='code') == set({'code/obj1.json', 'code/obj2.json'})
-    assert store.walk(src='code/') == set({'code/obj1.json', 'code/obj2.json'})
+    """Test querying a S3 bucket store using walk method."""
+
+    def result_keys(files):
+        return {key for key, _ in files}
+
+    assert result_keys(store.walk(src=None)) == bucket_keys
+    code_files = set({'code/obj1.json', 'code/obj2.json'})
+    assert result_keys(store.walk(src='code')) == code_files
+    assert result_keys(store.walk(src='code/')) == code_files
 
 
 def test_s3_open_file(store):
@@ -106,4 +111,4 @@ def test_s3_volume_subfolder(store, people):
     # Note that the file will not have been deleted in the original store. This
     # is because of how the unit tests are set up with each store having its
     # own full list of the files.
-    assert substore.walk(src=None) == set()
+    assert substore.walk(src=None) == []


### PR DESCRIPTION
This PR contains the following changes:

- Fix issue with `S3Volume.walk` return value

Closes #95