### PR TITLE
Feature/96 less restrictive copy files args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,3 +158,8 @@
 ### 0.9.3 - 2022-05-24
 
 * Fix issue with `S3Volume.walk` return value (\#95)
+
+
+### 0.9.4 - 2022-05-25
+
+* Make `path` argument for `copy_files` less restrictive (\#96)

--- a/flowserv/version.py
+++ b/flowserv/version.py
@@ -7,4 +7,4 @@
 # terms of the MIT License; see LICENSE file for more details.
 
 """Information about the current version of the flowServ package."""
-__version__ = '0.9.3'
+__version__ = '0.9.4'

--- a/flowserv/volume/base.py
+++ b/flowserv/volume/base.py
@@ -314,7 +314,7 @@ def copy_files(
             # make sure to remove the 'path' from all keys.
             for key, file in source_files:
                 if path:
-                    prefix = path + '/'
+                    prefix = path + '/' if not path.endswith('/') else path
                     key = key[len(prefix):]
                 dstpath = util.join(dst, key) if dst else key
                 files.append(dstpath)


### PR DESCRIPTION
This PR fixes the following issue:

- Make `path` argument in `copy_files` less restrictive. The code now handles argument values that end with `/` properly.

Closes #96 